### PR TITLE
Add Python 3.10 tests to Github Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         redis-version: ['5', '6', 'latest']
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -8,16 +8,17 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 __version__ = "1.2.0"
 
-setup(name='python-redis-cache',
-      version=__version__,
-      description='Basic Redis caching for functions',
-      long_description=long_description,
-      long_description_content_type='text/markdown',
-      url='http://github.com/taylorhakes/python-redis-cache',
-      author='Taylor Hakes',
-      license='MIT',
-      python_requires='>=3.6',
-      packages=find_packages(),
-      setup_requires=['pytest-runner==5.2'],
-      tests_require=['pytest==5.4.3', 'redis==3.5.3'],
+setup(
+    name='python-redis-cache',
+    version=__version__,
+    description='Basic Redis caching for functions',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    url='http://github.com/taylorhakes/python-redis-cache',
+    author='Taylor Hakes',
+    license='MIT',
+    python_requires='>=3.6',
+    packages=find_packages(),
+    setup_requires=['pytest-runner==5.3.1'],
+    tests_require=['pytest==6.2.5', 'redis==3.5.3'],
 )


### PR DESCRIPTION
@taylorhakes , would you kindly check this PR? It does the following:

- Adds Python 3.10 to Github Actions test matrix
- Updates `pytest` and `pytest-runner` to versions compatible with Python 3.10

