### PR TITLE
feat: Added redis sentinel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,53 @@
 [![license](https://img.shields.io/github/license/taylorhakes/python-redis-cache.svg)](https://github.com/taylorhakes/python-redis-cache/blob/master/LICENSE)
 
 # python-redis-cache
+
 Simple redis cache for Python functions
 
 ### Requirements
+
 - Redis 5+
 - Python 3.8+ (should work in Python 3.6+, but not tested)
 
 ## How to install
+
 ```
 pip install python-redis-cache
 ```
 
 ## How to use
+
+The Redis cache client can either connect to a standalone Redis server or to a sentinel managed Redis setup. Here's how you can initialize the cache client for these scenarios:
+
+### Standalone Redis setup
+
 ```python
 from redis import StrictRedis
 from redis_cache import RedisCache
 
 client = StrictRedis(host="redis", decode_responses=True)
 cache = RedisCache(redis_client=client)
+```
 
+### Sentinel Managed Redis setup
 
+```python
+from redis.sentinel import Sentinel
+from redis_cache import RedisCache
+
+# Here, redis-sentinel1 is the sentinel service name and mymaster is the name
+# of the master service.
+sentinel = Sentinel([('redis-sentinel1', 26379)],
+    password='topsecret',                               # redis server password
+    sentinel_kwargs={"password": "sentinel-topsecret"}  # sentinel password
+)
+
+cache = RedisCache(redis_client=sentinel)
+```
+
+### Using the cache
+
+```python
 @cache.cache()
 def my_func(arg1, arg2):
     result = some_expensive_operation()
@@ -43,6 +70,7 @@ my_func.invalidate_all()
 ```
 
 ## Limitations and things to know
+
 Arguments and return types must be JSON serializable by default. You can override the serializer, but be careful with using Pickle. Make sure you understand the security risks. Pickle should not be used with untrusted values.
 https://security.stackexchange.com/questions/183966/safely-load-a-pickle-file
 `decode_responses` parameter must be `False` in redis client if you use pickle.
@@ -51,6 +79,7 @@ https://security.stackexchange.com/questions/183966/safely-load-a-pickle-file
 - **limit** - The limit will revoke keys (once it hits the limit) based on FIFO, not based on LRU
 
 ## API
+
 ```python
 # Create the redis cache
 cache = RedisCache(redis_client, prefix="rc", serializer=dumps, deserializer=loads, key_serializer=None, exception_handler=None)

--- a/docker-compose-sentinel.yml
+++ b/docker-compose-sentinel.yml
@@ -1,0 +1,52 @@
+version: '3.7'
+services:
+  test:
+    image: python:${PY_VERSION:-3.9.16}
+    volumes:
+      - .:/python
+    command: ${TEST_COMMAND:-python setup.py test}
+    stdin_open: true
+    tty: true
+    working_dir: /python
+    environment:
+      - TEST_SENTINEL=true
+    depends_on:
+      - redis-master
+      - redis-slave1
+      - redis-slave2
+      - redis-sentinel1
+      - redis-sentinel2
+      - redis-sentinel3
+
+  redis-master:
+    image: redis:${REDIS_VERSION:-5}
+    command: redis-server --requirepass topsecret
+
+  redis-slave1:
+    image: redis:${REDIS_VERSION:-5}
+    command: redis-server --slaveof redis-master 6379 --requirepass topsecret --masterauth topsecret
+
+  redis-slave2:
+    image: redis:${REDIS_VERSION:-5}
+    command: redis-server --slaveof redis-master 6379 --requirepass topsecret --masterauth topsecret
+
+  redis-sentinel1:
+    image: bitnami/redis-sentinel:6.0
+    environment:
+      - REDIS_MASTER_HOST=redis-master
+      - REDIS_MASTER_PASSWORD=topsecret
+      - REDIS_SENTINEL_PASSWORD=sentinel-topsecret
+
+  redis-sentinel2:
+    image: bitnami/redis-sentinel:6.0
+    environment:
+      - REDIS_MASTER_HOST=redis-master
+      - REDIS_MASTER_PASSWORD=topsecret
+      - REDIS_SENTINEL_PASSWORD=sentinel-topsecret
+
+  redis-sentinel3:
+    image: bitnami/redis-sentinel:6.0
+    environment:
+      - REDIS_MASTER_HOST=redis-master
+      - REDIS_MASTER_PASSWORD=topsecret
+      - REDIS_SENTINEL_PASSWORD=sentinel-topsecret

--- a/test.sh
+++ b/test.sh
@@ -1,1 +1,4 @@
 docker-compose run --rm test
+docker-compose down
+docker-compose -f docker-compose-sentinel.yml run --rm test
+docker-compose -f docker-compose-sentinel.yml down


### PR DESCRIPTION
Added support for using a redis-sentinel setup. 

### Sentinel Managed Redis setup

```python
from redis.sentinel import Sentinel
from redis_cache import RedisCache

# Here, redis-sentinel1 is the sentinel service name and mymaster is the name
# of the master service.
sentinel = Sentinel([('redis-sentinel1', 26379)],
    password='topsecret',                               # redis server password
    sentinel_kwargs={"password": "sentinel-topsecret"}  # sentinel password
)

cache = RedisCache(redis_client=sentinel)
```