### PR TITLE
feat(active-flag): added the ability to disable the cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ cached_func.invalidate_all()
 - namespace - The string namespace of the cache. This is useful for allowing multiple functions to use the same cache. By default its `f'{function.__module__}.{function.__file__}'`
 - exception_handler - Function to handle Redis cache exceptions. This allows you to fall back to calling the original function or logging exceptions. Function has the following signature `exception_handler(exception: Exception, function: Callable, args: List, kwargs: Dict) -> Any`. If using this handler, reraise the exception in the handler to stop execution of the function. All return results will be used even if `None`. If handler not defined, it will raise the exception and not call the original function.
 - support_cluster - Set to False to disable the `{` prefix on the keys. This is NOT recommended. See below for more info.
+- active - Optional flag to disable the caching completly for troubleshooting/lower environments
+
 
 ## Limitations and things to know
 Arguments and return types must be JSON serializable by default. You can override the serializer, but be careful with using Pickle. Make sure you understand the security risks. Pickle should not be used with untrusted values.

--- a/tests/test_redis_cache.py
+++ b/tests/test_redis_cache.py
@@ -25,6 +25,10 @@ def cache():
     return RedisCache(redis_client=client)
 
 
+@pytest.fixture()
+def inactive_cache():
+    return RedisCache(redis_client=client, active=False)
+
 def add_func(n1, n2):
     """ Add function
     Add n1 to n2 and return a uuid4 unique verifier
@@ -66,6 +70,17 @@ def test_ttl(cache):
     assert 7 == r_1 == r_2 == r_3
     assert v_1 == v_2 != v_3
 
+def test_inactive_cache(inactive_cache):
+    @inactive_cache.cache(ttl=2)
+    def add_ttl(arg1, arg2):
+        return add_func(arg1, arg2)
+
+    r_1, v_1 = add_ttl(3, 4)
+    r_2, v_2 = add_ttl(3, 4)
+
+    assert 7 == r_1 == r_2
+    # In inactive scenario the calls should return different uuids
+    assert v_1 != v_2
 
 def test_limit(cache):
     @cache.cache(limit=2)


### PR DESCRIPTION
Hi @taylorhakes,
It's me again...
I hope that in this case we can add the parameter to the constructor.
A couple of things were on my mind.
1. Should it be called inactive:bool = False or active:bool = True. Went with the latter.
2. I don't really like the fact that I'm pushing the flag down to CacheDecorator but if I wanted the other way, I needed to create an "empty" class that implements the __call__, wraps and inner.
Looked more cumbersome and I think that having all the logic in one place makes the code easier to read.
But it's not my area of expertise so maybe I'm missing something.
I would love to have your input.

Thanks!