### PR TITLE
fix(cache): take into consideration positional-only args

### DIFF
--- a/redis_cache/__init__.py
+++ b/redis_cache/__init__.py
@@ -14,7 +14,7 @@ def get_args(fn, args, kwargs):
     them both the same. Otherwise there would be different caching for add(1, 2) and add(arg1=1, arg2=2)
     """
     arg_sig = signature(fn)
-    standard_args = [param.name for param in arg_sig.parameters.values() if param.kind is param.POSITIONAL_OR_KEYWORD]
+    standard_args = [param.name for param in arg_sig.parameters.values() if param.kind is param.POSITIONAL_OR_KEYWORD or param.kind is param.POSITIONAL_ONLY]
     allowed_kwargs = {param.name for param in arg_sig.parameters.values() if param.kind is param.POSITIONAL_OR_KEYWORD or param.kind is param.KEYWORD_ONLY}
     variable_args = [param.name for param in arg_sig.parameters.values() if param.kind is param.VAR_POSITIONAL]
     variable_kwargs = [param.name for param in arg_sig.parameters.values() if param.kind is param.VAR_KEYWORD]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
-__version__ = "3.2.0"
+__version__ = "4.0.0"
 
 setup(
     name='python-redis-cache',
@@ -17,7 +17,7 @@ setup(
     url='http://github.com/taylorhakes/python-redis-cache',
     author='Taylor Hakes',
     license='MIT',
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     packages=find_packages(),
     install_requires=['redis'],
     setup_requires=['pytest-runner==5.3.1'],

--- a/tests/test_redis_cache.py
+++ b/tests/test_redis_cache.py
@@ -362,6 +362,9 @@ def test_get_args(cache):
     def fn5(*, d, **e):
         pass
 
+    def fn6(a, b, /, c, d):
+        pass
+
     assert get_args(fn1, (1,2), {}) == dict(a=1, b=2)
     assert get_args(fn1, [], dict(a=1, b=2)) == dict(a=1, b=2)
     assert get_args(fn1, [1], dict(b=2)) == dict(a=1, b=2)
@@ -369,6 +372,7 @@ def test_get_args(cache):
     assert get_args(fn3, [1, 2, 3, 4], {}) == dict(c=[1, 2, 3, 4])
     assert get_args(fn4, [1, 2, 3, 4], dict(d=5, f=6, g=7, h=8)) == dict(a=1, c=[2, 3, 4], d=5, e=dict(f=6, g=7, h=8))
     assert get_args(fn5, [], dict(d=5, f=6, g=7, h=8)) == dict(d=5, e=dict(f=6, g=7, h=8))
+    assert get_args(fn6, [1, 2, 3], dict(d=4)) == dict(a=1, b=2, c=3, d=4)
 
 # Simulate the environment where redis is not available
 # Only test the CacheDecorator since the exception handling should be done inside the decorator


### PR DESCRIPTION
This PR allows arguments of functions defined with positional-only arguments to be parsed correctly into normalized arguments, instead of being ignored.

The parameters `a` and `b` in the following function definition are positional-only parameters:

```python
def foo(a, b, /, c, d):
    pass
``` 

## Current Behavior

The normalized args for `foo` for some defined `args` and `kwargs` are:

```python
get_args(foo, (1,2,3,), dict(d=4))
# {'c': 1, 'd': 4}
```

## Expected Behavior

```python
get_args(foo, (1,2,3,), dict(d=4))
# {'a': 1, 'b':2, 'c': 3, 'd': 4}
```