### PR TITLE
fix(cache): support for unpassed default args

### DIFF
--- a/redis_cache/__init__.py
+++ b/redis_cache/__init__.py
@@ -1,7 +1,7 @@
 from functools import wraps
 from json import dumps, loads
 from base64 import b64encode
-from inspect import signature
+from inspect import signature, Parameter
 
 def compact_dump(value):
     return dumps(value, separators=(',', ':'), sort_keys=True)
@@ -43,6 +43,10 @@ def get_args(fn, args, kwargs):
                 if vkwargs_name not in parsed_args:
                     parsed_args[vkwargs_name] = {}
                 parsed_args[vkwargs_name][key] = value
+
+    for param in arg_sig.parameters.values():
+        if param.name not in parsed_args and param.default is not Parameter.empty:
+            parsed_args[param.name] = param.default
 
     return parsed_args
 

--- a/redis_cache/__init__.py
+++ b/redis_cache/__init__.py
@@ -14,7 +14,7 @@ def get_args(fn, args, kwargs):
     them both the same. Otherwise there would be different caching for add(1, 2) and add(arg1=1, arg2=2)
     """
     arg_sig = signature(fn)
-    standard_args = [param.name for param in arg_sig.parameters.values() if param.kind is param.POSITIONAL_OR_KEYWORD]
+    standard_args = [param.name for param in arg_sig.parameters.values() if param.kind is param.POSITIONAL_OR_KEYWORD or param.kind is param.POSITIONAL_ONLY]
     allowed_kwargs = {param.name for param in arg_sig.parameters.values() if param.kind is param.POSITIONAL_OR_KEYWORD or param.kind is param.KEYWORD_ONLY}
     variable_args = [param.name for param in arg_sig.parameters.values() if param.kind is param.VAR_POSITIONAL]
     variable_kwargs = [param.name for param in arg_sig.parameters.values() if param.kind is param.VAR_KEYWORD]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
-__version__ = "3.2.0"
+__version__ = "4.0.0"
 
 setup(
     name='python-redis-cache',
@@ -17,7 +17,7 @@ setup(
     url='http://github.com/taylorhakes/python-redis-cache',
     author='Taylor Hakes',
     license='MIT',
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     packages=find_packages(),
     install_requires=['redis'],
     setup_requires=['pytest-runner==5.3.1'],

--- a/tests/test_redis_cache.py
+++ b/tests/test_redis_cache.py
@@ -365,6 +365,9 @@ def test_get_args(cache):
     def fn6(a, b, /, c, d):
         pass
 
+    def fn7(a, b, c=3, *, d):
+        pass
+
     assert get_args(fn1, (1,2), {}) == dict(a=1, b=2)
     assert get_args(fn1, [], dict(a=1, b=2)) == dict(a=1, b=2)
     assert get_args(fn1, [1], dict(b=2)) == dict(a=1, b=2)
@@ -373,6 +376,7 @@ def test_get_args(cache):
     assert get_args(fn4, [1, 2, 3, 4], dict(d=5, f=6, g=7, h=8)) == dict(a=1, c=[2, 3, 4], d=5, e=dict(f=6, g=7, h=8))
     assert get_args(fn5, [], dict(d=5, f=6, g=7, h=8)) == dict(d=5, e=dict(f=6, g=7, h=8))
     assert get_args(fn6, [1, 2, 3], dict(d=4)) == dict(a=1, b=2, c=3, d=4)
+    assert get_args(fn7, [1, 2], dict(d=4)) == dict(a=1, b=2, c=3, d=4)
 
 # Simulate the environment where redis is not available
 # Only test the CacheDecorator since the exception handling should be done inside the decorator

--- a/tests/test_redis_cache.py
+++ b/tests/test_redis_cache.py
@@ -362,6 +362,9 @@ def test_get_args(cache):
     def fn5(*, d, **e):
         pass
 
+    def fn6(a, b, /, c, d):
+        pass
+
     assert get_args(fn1, (1,2), {}) == dict(a=1, b=2)
     assert get_args(fn1, [], dict(a=1, b=2)) == dict(a=1, b=2)
     assert get_args(fn1, [1], dict(b=2)) == dict(a=1, b=2)
@@ -369,6 +372,7 @@ def test_get_args(cache):
     assert get_args(fn3, [1, 2, 3, 4], {}) == dict(c=[1, 2, 3, 4])
     assert get_args(fn4, [1, 2, 3, 4], dict(d=5, f=6, g=7, h=8)) == dict(a=1, c=[2, 3, 4], d=5, e=dict(f=6, g=7, h=8))
     assert get_args(fn5, [], dict(d=5, f=6, g=7, h=8)) == dict(d=5, e=dict(f=6, g=7, h=8))
+    assert get_args(fn6, [1, 2, 3], dict(d=4)) == dict(a=1, b=2, c=3, d=4)
 
 # Simulate the environment where redis is not available
 # Only test the CacheDecorator since the exception handling should be done inside the decorator


### PR DESCRIPTION
This PR is based on top of #38 and addressed the following:

Defined functions with some parameters holding default values, in which function calls without passing a value to these parameters, leads to them being ignored when being cached. I.e. the normalized args does not include args not passed to parameters with default values.

## Current Behavior

If function `foo` was defined as such:

```python
@cache
def foo(a, b=2):
  return a+b
```

Calls to `foo` that look like this: `foo(1)` would be cached based on the argument given to parameter `a`.
However, if this default value changes while the call to the function doesn't, then the same cache result is retrieved regardless of the value of `b` used inside the function.

```python
@cache
def foo(a, b=999):
  return a+b
```
```
# assuming the cached value is retained
foo(1) == 3  # before change
foo(1) == 3  # after change
```

## Expected Behavior

Since it would be safe to assume that defaults of parameters are used by the function's implementation, and thus potentially affect the return value, then it would be sensible to assume that a cached function call also depends on those defaults, which should be hashed consequently.

```
# assuming the cached value is retained
foo(1) == 3  # before change
foo(1) == 1000  # after change
```