### PR TITLE
Handle decorating async functions, add test for async function decoration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setup(
     packages=find_packages(),
     install_requires=['redis'],
     setup_requires=['pytest-runner==5.3.1'],
-    tests_require=['pytest==6.2.5', 'redis==4.4.4'],
+    tests_require=['pytest==8.3.2', 'pytest-asyncio==0.24.0', 'redis==4.4.4'],
 )

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/tests/test_redis_cache.py
+++ b/tests/test_redis_cache.py
@@ -70,6 +70,17 @@ def test_ttl(cache):
     assert 7 == r_1 == r_2 == r_3
     assert v_1 == v_2 != v_3
 
+
+async def test_async(cache):
+    @cache.cache()
+    async def async_fn(arg1):
+        return arg1
+
+    r1 = await async_fn(1)
+    r2 = await async_fn(1)
+    assert r1 == r2
+
+
 def test_inactive_cache(inactive_cache):
     @inactive_cache.cache(ttl=2)
     def add_ttl(arg1, arg2):
@@ -415,5 +426,3 @@ def test_basic_check_no_redis(no_redis_cache):
 
     assert 7 == r_3_4 == r_3_4_cached == r_3_4_cached_kwargs == r_3_4_cached_mix
     assert 10 == r_5_5 != r_3_4
-
-


### PR DESCRIPTION
These changes allow for the wrapped function to be an `async` function.

It does this by checking if the function that is being wrapped is a coroutine function.
If it is not a coroutine, wrapping is done the same as before.
If it is a coroutine (i.e. an `async` function), then the wrapper is async, and when the underlying function is called, we add the `await` keyword. This is necessary so that we can capture the response from the function, and cache it.

If you have any feedback, or require any changes, please let me know!

resolves #41 