### PR TITLE
fix: route cache-write failures through exception_handler

### DIFF
--- a/redis_cache/__init__.py
+++ b/redis_cache/__init__.py
@@ -230,9 +230,15 @@ class CacheDecorator:
             if result:
                 parsed_result = self.deserializer(result)
             elif not exception_handled:
-                parsed_result = fn(*args, **kwargs)
-                result_serialized = self.serializer(parsed_result)
-                get_cache_lua_fn(self.client)(keys=[key, self.keys_key], args=[result_serialized, self.ttl, self.limit])
+                try:
+                    parsed_result = fn(*args, **kwargs)
+                    result_serialized = self.serializer(parsed_result)
+                    get_cache_lua_fn(self.client)(keys=[key, self.keys_key], args=[result_serialized, self.ttl, self.limit])
+                except Exception as e:
+                    if self.exception_handler:
+                        parsed_result = self.exception_handler(e, self.original_fn, args, kwargs)
+                    else:
+                        raise e
 
             return parsed_result
 


### PR DESCRIPTION
## Problem
`exception_handler` currently only protects the cache **read**: `client.get(key)` is wrapped in try/except, but on a cache miss the write path is not. If Redis becomes unavailable between the failed `get` and the subsequent store (or the store itself fails — e.g. connection drop, OOM, cluster failover), the exception propagates to the caller even though an `exception_handler` was configured to make caching failures non-fatal.

## Fix
Wrap the cache-miss path (calling the original function, serializing the result, and the Lua cache-set script) in a try/except that delegates to `exception_handler` when one is configured, matching the existing behaviour of the read path. Without a handler, the exception is re-raised, so behaviour is unchanged for users who don't use `exception_handler`.

```python
elif not exception_handled:
    try:
        parsed_result = fn(*args, **kwargs)
        result_serialized = self.serializer(parsed_result)
        get_cache_lua_fn(self.client)(keys=[key, self.keys_key], args=[result_serialized, self.ttl, self.limit])
    except Exception as e:
        if self.exception_handler:
            parsed_result = self.exception_handler(e, self.original_fn, args, kwargs)
        else:
            raise e
```

The handler receives the same `(exception, original_fn, args, kwargs)` signature as on the read path, so existing handlers (which typically fall back to calling the function directly) work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)